### PR TITLE
fix the purple background when using transparent gif

### DIFF
--- a/DiscordPlus-source.theme.css
+++ b/DiscordPlus-source.theme.css
@@ -810,8 +810,8 @@ padding: var(--dplus-spacing-ui);
 
 /* Emoji/GIF/Sticker Picker */
 .result-3w1ZcL, .wrapper-1-Fsb8 {
-	background-color: var(--dplus-accent-ui)!important;
-	border-radius: var(--dplus-radius-ui);
+    background-color: transparent !important;
+    border-radius: var(--dplus-radius-ui);
 }
 #app-mount .focused-1En8bG:after, .theme-dark .result-3w1ZcL:hover:after {
     box-shadow: inset 0 0 0 2px var(--dplus-accent-ui), inset 0 0 0 3px #2f3136;


### PR DESCRIPTION
make the gif picker's background transparent while choosing transparent gif

before:
https://media.discordapp.net/attachments/554906163863486467/925675669298499614/unknown.png

after:
https://media.discordapp.net/attachments/554906163863486467/925675850626637844/unknown.png