### PR TITLE
Fixes spacing error around edges post-update

### DIFF
--- a/src/DiscordPlus-source.theme.css
+++ b/src/DiscordPlus-source.theme.css
@@ -1189,6 +1189,10 @@ margin-right: 0;
 	border-radius: var(--dplus-radius-ui);
 	overflow: hidden!important;
 }
+
+.layers__1c917  {
+  margin: 5px 15px 15px 5px!important;
+}
     /*-- 12.2 Friends List --*/
 #app-mount .container__5c7e7, #app-mount .outer_a41cf3 {background-color: var(--dplus-bgc-ui-base)!important;}
 .nowPlayingColumn_f5023f, .container__5c7e7 .container__11d72.themed_b152d4, .container__0a6a9 {background-color: transparent!important;}

--- a/src/DiscordPlus-source.theme.css
+++ b/src/DiscordPlus-source.theme.css
@@ -1189,9 +1189,9 @@ margin-right: 0;
 	border-radius: var(--dplus-radius-ui);
 	overflow: hidden!important;
 }
-
+ 
 .layers__1c917  {
-  margin: 5px 15px 15px 5px!important;
+  margin: 5px 15px 15px 5px!important; /* fixes spacing issues on edge of main section */ 
 }
     /*-- 12.2 Friends List --*/
 #app-mount .container__5c7e7, #app-mount .outer_a41cf3 {background-color: var(--dplus-bgc-ui-base)!important;}


### PR DESCRIPTION
Brings the spacing back in line with how it was before the variable name changes. Applies to settings and chat UIs.

Before:
![image](https://github.com/PlusInsta/discord-plus/assets/113630709/7e6e3727-c048-4c50-b662-ca62052db017)
After:
![image](https://github.com/PlusInsta/discord-plus/assets/113630709/9a78acb8-c17d-4a12-8fb5-7930caba55a4)

I hope this helps! 