### PR TITLE
Fix spacing with compact mode + avatar on

### DIFF
--- a/src/DiscordPlus-source.theme.css
+++ b/src/DiscordPlus-source.theme.css
@@ -987,7 +987,7 @@ margin-right: 0;
 	z-index: 2;
 }
 		/*- 12.4.1 Message Seperation -*/	
-:is(.messageListItem__5126c, .quotedChatMessage__5126c, .flash__03436):has(+ .messageListItem__5126c .groupStart__5126c,  + .flash__03436 .groupStart__5126c, + .scrollerSpacer__36d07, + .divider__5126c) .groupStart__5126c:has(.avatar_c19a55) 	{
+:is(.messageListItem__5126c, .quotedChatMessage__5126c, .flash__03436):has(+ .messageListItem__5126c .groupStart__5126c,  + .flash__03436 .groupStart__5126c, + .scrollerSpacer__36d07, + .divider__5126c) .groupStart__5126c:has(.avatar_c19a55:not(.compact_c19a55)) 	{
 	min-height: calc(var(--dplus-spacing-ui)*2 + var(--dplus-icon-avatar-chat));
 	padding-top: 0; padding-bottom: 0;
 }


### PR DESCRIPTION
There was a spacing error when Appearance > Message Spacing > Chat Message Display is set to "Compact" and Hide user avatars is turned off

before:
![image](https://github.com/user-attachments/assets/77979cf6-8754-4cbc-bd2e-205b8656b27f)

after:
![image](https://github.com/user-attachments/assets/f35490d9-9fdf-46a3-aef8-e04dd62b79ac)
