### PR TITLE
Ideally a fix for the unthemed DM background

### DIFF
--- a/src/DiscordPlus-source.theme.css
+++ b/src/DiscordPlus-source.theme.css
@@ -715,6 +715,9 @@ background-color: var(--dplus-bgc-server-button-hover);
 .scrollerBase__99f8c, .privateChannels__35e86 {
 	background-color: transparent!important;
 }
+.privateChannels_e6b769 {
+	background: var(--dplus-bgc-ui-base) !important;
+}
 .visual-refresh .scroller__99e7c {margin-bottom: 0;}
 .privateChannels__35e86 .channel__972a0 {
 	margin-left: var(--dplus-spacing-ui);


### PR DESCRIPTION
Not too big of a change, imo
I don't know if this is a *permanent* fix for the issue, but I put this chunk into my custom CSS and the problem was fixed
Making the fork for this pull request in the first place, I temporarily switched the source file, and it also seemed to fix the issue
I haven't seen it breaking anything else? But I also don't have access to anyone else's configurations, I've just seen at least two other people talking about this problem, and knew I also had the issue

Also, if there's a better way to go about this, feel free to use that instead, I just know this works for me and mostly follows some of the other CSS I've seen from the theme