### PR TITLE
New image host + default light mode wallpaper

### DIFF
--- a/DiscordPlus.theme.css
+++ b/DiscordPlus.theme.css
@@ -3,7 +3,7 @@
  * @author PlusInsta
  * @authorId 309931975102300160
  * @authorLink https://plusinsta.xyz
- * @version 3.4.0
+ * @version 3.4.1
  * @description A sleek, customizable Discord theme.
  * @donate https://ko-fi.com/plusinsta
  * @website https://plusinsta.github.io/discord-plus


### PR DESCRIPTION
Light mode wallpaper has been sitting in my files for the last five years, untouched. It's not really "new" but I figured since I'm first gonna be changing image host, I should get it uploaded. 
Both images are lossless WebP, because it's more efficient than PNG. For some reason, the light version is way bigger than the dark version, even though both have roughly the same amount of unique colors. Beats me why.

Since this change is going to affect all future users, I want to get this looked at before I merge. In particular, I wonder about performance and loading times. If it's not too different on the reviewers' machines from the existing stuff, I'll merge it. If there's a sudden several second gap of no image, then I have to go back to the drawing board; maybe literally.

This fixes #106 and #109.